### PR TITLE
added copyright notice to Apache license file

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -187,7 +187,8 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2002-2017 Microsoft Corp.
+   Copyright 2007-2013 MindTouch, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The `license.txt` file was missing the copyright holders information. This pull requests adds that information and makes it consistent with the copyright notices found in other places in the code.