### PR TITLE
Add a command-line build script for MSBuild

### DIFF
--- a/BUILD.cmd
+++ b/BUILD.cmd
@@ -1,0 +1,20 @@
+
+@WHERE msbuild
+@IF %ERRORLEVEL% NEQ 0 (
+	@echo "Run this script from the Visual Studio Developer Command Prompt"
+	exit /B
+)
+
+@WHERE pwsh >NUL 2>NUL
+@IF %ERRORLEVEL% NEQ 0 (
+	@echo "Installing 'pwsh' (PowerShell Core)"
+	dotnet tool install --global powershell
+)
+
+pwsh -f Common/setup.ps1
+
+REM Restore NuGet packages:
+msbuild -t:restore SgmlReader.sln
+
+REM Build the solution:
+msbuild SgmlReader.sln

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ If you fix an issue, please submit PR and follow these guidelines:
 
 ## Building SgmlReader
 
+### Using `dotnet build`
+
 The build versioning system depends on `pwsh` and you can install that using:
 
 ```
@@ -144,6 +146,14 @@ And now you can build successfully:
 ```
 dotnet build SgmlReaderCore.sln
 ```
+
+### Using MSBuild
+
+1. Open your Visual Studio Developer Command Prompt - or any cmd session where `msbuild` is in the `PATH`.
+2. `cd <directory containing SgmlReader.sln>`
+3. `BUILD.cmd`
+
+The `BUILD.cmd` script will automatically install `pwsh` if necessary, run `setup.ps1`, restore NuGet packages, and build the solution using the default configuration.
 
 ## Versioning
 
@@ -163,8 +173,7 @@ git config --add filter.version.smudge "pwsh -f Common/smudge_version.ps1 %f"
 git config --add filter.version.clean "pwsh -f Common/clean_version.ps1 %f"
 ```
 
-When you "stage" a change to any one of these files the real version number will be replaced by
-$version. When you checkout or pull an update to one of these files the $version will be replaced
+When you "stage" a change to any one of these files the real version number will be replaced by the string "`$version`". When you checkout or pull an update to one of these files the string "`$version`" will be replaced
 with the real version from `versions.txt`.
 
 ### Developer Checklist

--- a/SgmlReader.sln
+++ b/SgmlReader.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
@@ -13,10 +12,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SgmlReaderUniversal", "Sgml
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A55E734A-D5D5-4491-83C0-DDC477E094D0}"
 	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		BUILD.cmd = BUILD.cmd
 		license.txt = license.txt
 		NuGet.config = NuGet.config
 		readme.md = readme.md
 		SgmlReader.nuspec = SgmlReader.nuspec
+		Common\version.props = Common\version.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SgmlReaderCore", "SgmlReaderCore\SgmlReaderCore.csproj", "{8572B8DD-B915-44DE-8B61-0AB3772F9C55}"


### PR DESCRIPTION
Fix for https://github.com/lovettchris/SgmlReader/issues/16 

This also updates the `README.md` with instructions for using this as an alternative to `dotnet build`.