### PR TITLE
Avoid throwing exceptions for known invalid attribute names

### DIFF
--- a/SgmlReaderDll/SgmlReader.cs
+++ b/SgmlReaderDll/SgmlReader.cs
@@ -2567,6 +2567,9 @@ namespace Sgml
 
         private static bool ValidAttributeName(string name)
         {
+            if (string.IsNullOrWhiteSpace(name))
+                return false;
+
             try
             {
                 XmlConvert.VerifyNMTOKEN(name);


### PR DESCRIPTION
Null, empty or all whitespaces are known invalid values for
attribute names. We can short-circuit this path and avoid
unnecessarily throwing exceptions for a common path.

When debugging a project that consumes SgmlReader, this
constant throwing slows things down tremendously, so this
is a low-hanging fruit win.