### PR TITLE
Remove file names from target attributes in .nuspec

### DIFF
--- a/SgmlReader.nuspec
+++ b/SgmlReader.nuspec
@@ -51,7 +51,7 @@
     <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.pdb" target="lib\net6.0" />
     <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.xml" target="lib\net6.0" />
     <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="lib\netcoreapp3.1" />
-    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="lib\netcoreapp3.1" />
+    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.pdb" target="lib\netcoreapp3.1" />
     <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.xml" target="lib\netcoreapp3.1" />
     <file src="SgmlReaderDll\bin\Release\netstandard2.0\SgmlReaderDll.dll" target="lib\netstandard2.0" />
     <file src="SgmlReaderDll\bin\Release\netstandard2.0\SgmlReaderDll.pdb" target="lib\netstandard2.0" />

--- a/SgmlReader.nuspec
+++ b/SgmlReader.nuspec
@@ -32,73 +32,73 @@
   </metadata>
   <files>
     <!-- libraries -->
-    <file src="SgmlReader\bin\Release\net45\SgmlReaderDll.dll" target="lib\net45\SgmlReaderDll.dll" />
-    <file src="SgmlReader\bin\Release\net45\SgmlReaderDll.pdb" target="lib\net45\SgmlReaderDll.pdb" />
-    <file src="SgmlReader\bin\Release\net45\SgmlReaderDll.xml" target="lib\net45\SgmlReaderDll.xml" />   
-    <file src="SgmlReader\bin\Release\net46\SgmlReaderDll.dll" target="lib\net46\SgmlReaderDll.dll" />
-    <file src="SgmlReader\bin\Release\net46\SgmlReaderDll.pdb" target="lib\net46\SgmlReaderDll.pdb" />
-    <file src="SgmlReader\bin\Release\net46\SgmlReaderDll.xml" target="lib\net46\SgmlReaderDll.xml" />
-    <file src="SgmlReader\bin\Release\net47\SgmlReaderDll.dll" target="lib\net47\SgmlReaderDll.dll" />
-    <file src="SgmlReader\bin\Release\net47\SgmlReaderDll.pdb" target="lib\net47\SgmlReaderDll.pdb" />
-    <file src="SgmlReader\bin\Release\net47\SgmlReaderDll.xml" target="lib\net47\SgmlReaderDll.xml" />
-    <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.dll" target="lib\net48\SgmlReaderDll.dll" />
-    <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.pdb" target="lib\net48\SgmlReaderDll.pdb" />
-    <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.xml" target="lib\net48\SgmlReaderDll.xml" />
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="lib\net5.0\SgmlReaderDll.dll" />
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="lib\net5.0\SgmlReaderDll.pdb" />
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="lib\net5.0\SgmlReaderDll.xml" />
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="lib\net6.0\SgmlReaderDll.dll" />
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="lib\net6.0\SgmlReaderDll.pdb" />
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="lib\net6.0\SgmlReaderDll.xml" />
-    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="lib\netcoreapp3.1\SgmlReaderDll.dll" />
-    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="lib\netcoreapp3.1\SgmlReaderDll.pdb" />
-    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.xml" target="lib\netcoreapp3.1\SgmlReaderDll.xml" />
-    <file src="SgmlReaderDll\bin\Release\netstandard2.0\SgmlReaderDll.dll" target="lib\netstandard2.0\SgmlReaderDll.dll" />
-    <file src="SgmlReaderDll\bin\Release\netstandard2.0\SgmlReaderDll.pdb" target="lib\netstandard2.0\SgmlReaderDll.pdb" />
-    <file src="SgmlReaderDll\bin\Release\netstandard2.0\SgmlReaderDll.xml" target="lib\netstandard2.0\SgmlReaderDll.xml" />
-    <file src="SgmlReaderDll\bin\Release\netstandard2.1\SgmlReaderDll.dll" target="lib\netstandard2.1\SgmlReaderDll.dll" />
-    <file src="SgmlReaderDll\bin\Release\netstandard2.1\SgmlReaderDll.pdb" target="lib\netstandard2.1\SgmlReaderDll.pdb" />
-    <file src="SgmlReaderDll\bin\Release\netstandard2.1\SgmlReaderDll.xml" target="lib\netstandard2.1\SgmlReaderDll.xml" />
-    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderUniversal.dll" target="lib\uap\SgmlReaderUniversal.dll" />
-    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderUniversal.pdb" target="lib\uap\SgmlReaderUniversal.pdb" />
-    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderUniversal.xml" target="lib\uap\SgmlReaderUniversal.xml" />
-    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderDll.dll" target="lib\uap\SgmlReaderDll.dll" />
-    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderDll.pdb" target="lib\uap\SgmlReaderDll.pdb" />
-    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderDll.xml" target="lib\uap\SgmlReaderDll.xml" />
+    <file src="SgmlReader\bin\Release\net45\SgmlReaderDll.dll" target="lib\net45" />
+    <file src="SgmlReader\bin\Release\net45\SgmlReaderDll.pdb" target="lib\net45" />
+    <file src="SgmlReader\bin\Release\net45\SgmlReaderDll.xml" target="lib\net45" />   
+    <file src="SgmlReader\bin\Release\net46\SgmlReaderDll.dll" target="lib\net46" />
+    <file src="SgmlReader\bin\Release\net46\SgmlReaderDll.pdb" target="lib\net46" />
+    <file src="SgmlReader\bin\Release\net46\SgmlReaderDll.xml" target="lib\net46" />
+    <file src="SgmlReader\bin\Release\net47\SgmlReaderDll.dll" target="lib\net47" />
+    <file src="SgmlReader\bin\Release\net47\SgmlReaderDll.pdb" target="lib\net47" />
+    <file src="SgmlReader\bin\Release\net47\SgmlReaderDll.xml" target="lib\net47" />
+    <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.dll" target="lib\net48" />
+    <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.pdb" target="lib\net48" />
+    <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.xml" target="lib\net48" />
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="lib\net5.0" />
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="lib\net5.0" />
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="lib\net5.0" />
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="lib\net6.0" />
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="lib\net6.0" />
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="lib\net6.0" />
+    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="lib\netcoreapp3.1" />
+    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="lib\netcoreapp3.1" />
+    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.xml" target="lib\netcoreapp3.1" />
+    <file src="SgmlReaderDll\bin\Release\netstandard2.0\SgmlReaderDll.dll" target="lib\netstandard2.0" />
+    <file src="SgmlReaderDll\bin\Release\netstandard2.0\SgmlReaderDll.pdb" target="lib\netstandard2.0" />
+    <file src="SgmlReaderDll\bin\Release\netstandard2.0\SgmlReaderDll.xml" target="lib\netstandard2.0" />
+    <file src="SgmlReaderDll\bin\Release\netstandard2.1\SgmlReaderDll.dll" target="lib\netstandard2.1" />
+    <file src="SgmlReaderDll\bin\Release\netstandard2.1\SgmlReaderDll.pdb" target="lib\netstandard2.1" />
+    <file src="SgmlReaderDll\bin\Release\netstandard2.1\SgmlReaderDll.xml" target="lib\netstandard2.1" />
+    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderUniversal.dll" target="lib\uap" />
+    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderUniversal.pdb" target="lib\uap" />
+    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderUniversal.xml" target="lib\uap" />
+    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderDll.dll" target="lib\uap" />
+    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderDll.pdb" target="lib\uap" />
+    <file src="SgmlReaderUniversal\bin\Release\SgmlReaderDll.xml" target="lib\uap" />
     
     <!-- command line tool -->
-    <file src="SgmlReader\bin\Release\net45\SgmlReader.exe" target="tools\net45\SgmlReader.exe" />
-    <file src="SgmlReader\bin\Release\net45\SgmlReader.pdb" target="tools\net45\SgmlReader.pdb" />    
-    <file src="SgmlReader\bin\Release\net45\SgmlReaderDll.dll" target="tools\net45\SgmlReaderDll.dll" />
+    <file src="SgmlReader\bin\Release\net45\SgmlReader.exe" target="tools\net45" />
+    <file src="SgmlReader\bin\Release\net45\SgmlReader.pdb" target="tools\net45" />    
+    <file src="SgmlReader\bin\Release\net45\SgmlReaderDll.dll" target="tools\net45" />
     
-    <file src="SgmlReader\bin\Release\net46\SgmlReader.exe" target="tools\net46\SgmlReader.exe" />
-    <file src="SgmlReader\bin\Release\net46\SgmlReader.pdb" target="tools\net46\SgmlReader.pdb" />
-    <file src="SgmlReader\bin\Release\net46\SgmlReaderDll.dll" target="tools\net46\SgmlReaderDll.dll" />
+    <file src="SgmlReader\bin\Release\net46\SgmlReader.exe" target="tools\net46" />
+    <file src="SgmlReader\bin\Release\net46\SgmlReader.pdb" target="tools\net46" />
+    <file src="SgmlReader\bin\Release\net46\SgmlReaderDll.dll" target="tools\net46" />
     
-    <file src="SgmlReader\bin\Release\net47\SgmlReader.exe" target="tools\net47\SgmlReader.exe" />
-    <file src="SgmlReader\bin\Release\net47\SgmlReader.pdb" target="tools\net47\SgmlReader.pdb" />
-    <file src="SgmlReader\bin\Release\net47\SgmlReaderDll.dll" target="tools\net47\SgmlReaderDll.dll" />
+    <file src="SgmlReader\bin\Release\net47\SgmlReader.exe" target="tools\net47" />
+    <file src="SgmlReader\bin\Release\net47\SgmlReader.pdb" target="tools\net47" />
+    <file src="SgmlReader\bin\Release\net47\SgmlReaderDll.dll" target="tools\net47" />
     
-    <file src="SgmlReader\bin\Release\net48\SgmlReader.exe" target="tools\net48\SgmlReader.exe" />
-    <file src="SgmlReader\bin\Release\net48\SgmlReader.pdb" target="tools\net48\SgmlReader.pdb" />
-    <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.dll" target="tools\net48\SgmlReaderDll.dll" />
+    <file src="SgmlReader\bin\Release\net48\SgmlReader.exe" target="tools\net48" />
+    <file src="SgmlReader\bin\Release\net48\SgmlReader.pdb" target="tools\net48" />
+    <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.dll" target="tools\net48" />
     
-    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReader.exe" target="tools\netcoreapp3.1\SgmlReader.exe" />
-    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReader.dll" target="tools\netcoreapp3.1\SgmlReader.dll" />
-    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReader.pdb" target="tools\netcoreapp3.1\SgmlReader.pdb" />
-    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReader.runtimeconfig.json" target="tools\netcoreapp3.1\SgmlReader.runtimeconfig.json"/>
-    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="tools\netcoreapp3.1\SgmlReaderDll.dll" />
+    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReader.exe" target="tools\netcoreapp3.1" />
+    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReader.dll" target="tools\netcoreapp3.1" />
+    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReader.pdb" target="tools\netcoreapp3.1" />
+    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReader.runtimeconfig.json" target="tools\netcoreapp3.1"/>
+    <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="tools\netcoreapp3.1" />
     
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReader.exe" target="tools\net5.0\SgmlReader.exe" />
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReader.dll" target="tools\net5.0\SgmlReader.dll" />
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReader.exe" target="tools\net5.0\SgmlReader.pdb" />
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReader.runtimeconfig.json" target="tools\net5.0\SgmlReader.runtimeconfig.json"/>
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="tools\net5.0\SgmlReaderDll.dll" />
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReader.exe" target="tools\net5.0" />
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReader.dll" target="tools\net5.0" />
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReader.exe" target="tools\net5.0" />
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReader.runtimeconfig.json" target="tools\net5.0"/>
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="tools\net5.0" />
 
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReader.exe" target="tools\net6.0\SgmlReader.exe" />
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReader.dll" target="tools\net6.0\SgmlReader.dll" />
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReader.exe" target="tools\net6.0\SgmlReader.pdb" />
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReader.runtimeconfig.json" target="tools\net6.0\SgmlReader.runtimeconfig.json"/>
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="tools\net6.0\SgmlReaderDll.dll" />
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReader.exe" target="tools\net6.0" />
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReader.dll" target="tools\net6.0" />
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReader.exe" target="tools\net6.0" />
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReader.runtimeconfig.json" target="tools\net6.0"/>
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="tools\net6.0" />
   </files>
 </package>

--- a/SgmlReader.nuspec
+++ b/SgmlReader.nuspec
@@ -45,11 +45,11 @@
     <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.pdb" target="lib\net48" />
     <file src="SgmlReader\bin\Release\net48\SgmlReaderDll.xml" target="lib\net48" />
     <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="lib\net5.0" />
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="lib\net5.0" />
-    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.dll" target="lib\net5.0" />
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.pdb" target="lib\net5.0" />
+    <file src="SgmlReader\bin\Release\net5.0\SgmlReaderDll.xml" target="lib\net5.0" />
     <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="lib\net6.0" />
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="lib\net6.0" />
-    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.dll" target="lib\net6.0" />
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.pdb" target="lib\net6.0" />
+    <file src="SgmlReader\bin\Release\net6.0\SgmlReaderDll.xml" target="lib\net6.0" />
     <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="lib\netcoreapp3.1" />
     <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.dll" target="lib\netcoreapp3.1" />
     <file src="SgmlReader\bin\Release\netcoreapp3.1\SgmlReaderDll.xml" target="lib\netcoreapp3.1" />


### PR DESCRIPTION
The `target` attribute in the .nuspec refers to a folder/directory, not a filename. The .xml and .pdb files were ending up in their own separate directories in the package instead of where they should have been.

See: https://learn.microsoft.com/en-us/nuget/reference/nuspec#including-assembly-files
